### PR TITLE
EE-13343 Added AUDITING_DEPLOYMENT_NAMESPACE to environment variables

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -173,6 +173,10 @@ spec:
                 secretKeyRef:
                   name: db-secrets
                   key: application_password
+            - name: AUDITING_DEPLOYMENT_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           resources:
             limits:
               cpu: 1600m


### PR DESCRIPTION
The audit-service wasn't reporting on suspicious activity because this environment variable wasn't set and, therefore, the database queries were always returning 0 results. See https://github.com/UKHomeOffice/pttg-ip-audit/pull/43 for changes to audit-service to stop such issues arising again.